### PR TITLE
is now possible to import components without suffixing .js

### DIFF
--- a/src/hooks/playground/useEsbuild.ts
+++ b/src/hooks/playground/useEsbuild.ts
@@ -68,6 +68,13 @@ export default function useEsbuild(vfsFromUrl: VFS | null) {
                         }
                     }
 
+                    if (args.path.startsWith('./') && vfs[`${args.path.substring(2)}.js`]) {
+                        return {
+                            namespace: 'a',
+                            path: `${args.path.substring(2)}.js`
+                        }
+                    }
+
                     if (args.path.includes('./') || args.path.includes('../')) {
                         return {
                         namespace: 'a',


### PR DESCRIPTION
Make it possible to import components without declaring `.js` (e.g. `import test from './test` instead of  `import test from './test.js`).
Both suffixed and unsuffixed syntaxes should be valid.