### PR TITLE
fixed

### DIFF
--- a/src/components/esthetic/MobileVerticalSplitPane.tsx
+++ b/src/components/esthetic/MobileVerticalSplitPane.tsx
@@ -34,21 +34,21 @@ function MobileTabDisplayer(props: Props) {
                     {
                         showEditor ?
                             <>
-                                <ExpandSVG
-                                    direction={"left"}
-                                    height={"20px"}
-                                    width={"20px"}
-                                />
                                 {Tabs.RIGHT}
-                            </>
-                        :
-                            <>
-                                {Tabs.LEFT}
                                 <ExpandSVG
                                     direction={"right"}
                                     height={"20px"}
                                     width={"20px"}
                                 />
+                            </>
+                        :
+                            <>
+                                <ExpandSVG
+                                    direction={"left"}
+                                    height={"20px"}
+                                    width={"20px"}
+                                />
+                                {Tabs.LEFT}
                             </>
                     }
                     <TabCheckbox

--- a/src/components/playground/Playground.tsx
+++ b/src/components/playground/Playground.tsx
@@ -102,7 +102,8 @@ function Playground(props: Props) {
 }
 
 const Page = styled.div`
-    margin-top: 45px;
+    position: fixed;
+    top: 45px;
     height: calc(100vh - 45px);
     width: 100vw;
     max-height: 100%;


### PR DESCRIPTION
On mobile the part below scrolls on the navbar. Fixed.
Also, in the mobile split pane the arrows were reversed. Fixed.