### PR TITLE
Lazy loading of the editor + key to codemirror component

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -77,6 +77,7 @@ function Editor(props: Props) {
             <Scroller>
                 <CodeMirroContainer>
                     <CodeMirror
+                        key={currentFile}
                         value={filesById[currentFile]}
                         theme={sublimish}
                         extensions={[

--- a/src/components/editor/EditorFallback.tsx
+++ b/src/components/editor/EditorFallback.tsx
@@ -1,0 +1,19 @@
+import Loader from '@/components/ui-elements/Loader'
+import styled from 'styled-components'
+
+
+export default function EditorFallback() {
+    return (
+        <Container>
+            <Loader />
+        </Container>
+    )
+}
+
+const Container = styled.section`
+    height: 100%;
+    max-height: 100%;
+    flex-grow: 1;
+    display: grid;
+    place-content: center;
+`

--- a/src/components/playground/Playground.tsx
+++ b/src/components/playground/Playground.tsx
@@ -1,5 +1,5 @@
-import Editor from '@/components/editor/Editor'
 import Navbar from '@/components/playground/Navbar'
+import EditorFallback from '@/components/editor/EditorFallback'
 import MiniBrowser from '@/components/output/MiniBrowser'
 import VerticalSplitPane from '@/components/ui-elements/VerticalSplitPane'
 import useEsbuild from '@/hooks/playground/useEsbuild'
@@ -8,8 +8,11 @@ import { colors, fixedSizes } from '@/tools/style-tools'
 import { generatePayload } from '@/tools/editor.tools'
 import { exportToCodeSandbox, exportToStackblitz, exportToZip } from '@/tools/exports-tools'
 import { useCreateEvento } from 'evento-react'
-import { useCallback, useEffect } from 'react'
+import { lazy, Suspense, useCallback, useEffect } from 'react'
 import styled from 'styled-components'
+
+const Editor = lazy(() => import('@/components/editor/Editor'))
+
 
 interface Props {
     initialVFS: VFS | null,
@@ -101,13 +104,15 @@ function Playground(props: Props) {
             />
             <VerticalSplitPane
                 leftPaneChild={
-                    <Editor
-                        onAddFile={handleAddFile}
-                        onDeleteFile={handleDeleteFile}
-                        onEditFileName={handleEditFileName}
-                        files={files}
-                        onTextEditorChange={handleTextEditorChange}
-                    />
+                    <Suspense fallback={<EditorFallback />}>
+                        <Editor
+                            onAddFile={handleAddFile}
+                            onDeleteFile={handleDeleteFile}
+                            onEditFileName={handleEditFileName}
+                            files={files}
+                            onTextEditorChange={handleTextEditorChange}
+                        />
+                    </Suspense>
                 }
                 rightPaneChild={
                     <MiniBrowser


### PR DESCRIPTION
This PR lazy loads the Editor component, to reduce bundle-size.
Also, added a `key` prop to CodeMirror element, in order to re-render the textarea and fix bug that had `ctrl - Z` sometimes replacing content of tab with other tabs previously open 