### PR TITLE
RP removed pin from CDN url

### DIFF
--- a/src/hooks/playground/useEsbuild.ts
+++ b/src/hooks/playground/useEsbuild.ts
@@ -22,7 +22,7 @@ export type OutputType = OutputTypeSuccess | OutputTypeFail
 
 export const CDN = 'https://esm.sh'
 
-export const make_CDN_URL = (pkg: string) => `${CDN}/${pkg}?pin=v92`
+export const make_CDN_URL = (pkg: string) => `${CDN}/${pkg}`
 
 const fileCache = localforage.createInstance({
     name: 'filecache',


### PR DESCRIPTION
CDN's url has a `?pin=v92` added at the end; probably is now unuseful.
Revert if problems